### PR TITLE
Add 'doctrine_orm.simple_annotation_reader' parameter to use on secon…

### DIFF
--- a/lib/Palma/Silex/Provider/DoctrineORMServiceProvider.php
+++ b/lib/Palma/Silex/Provider/DoctrineORMServiceProvider.php
@@ -49,7 +49,7 @@ class DoctrineORMServiceProvider implements ServiceProviderInterface {
 	        } else {
 	        	$configuration->setMetadataCacheImpl(new ArrayCache());
 	        }
-            $driverImpl = $configuration->newDefaultAnnotationDriver($app['doctrine_orm.entities_path']);
+            $driverImpl = $configuration->newDefaultAnnotationDriver($app['doctrine_orm.entities_path'], boolval($app['doctrine_orm.simple_annotation_reader']));
             $configuration->setMetadataDriverImpl($driverImpl);
 
             if(isset($app['doctrine_orm.query_cache'])){


### PR DESCRIPTION
…d parameter from newDefaultAnnotationDriver method, to use annotations like @ORM\Entity on entities class.